### PR TITLE
temp fix: disable destory_process_group

### DIFF
--- a/multiworld/world_manager.py
+++ b/multiworld/world_manager.py
@@ -173,7 +173,10 @@ class WorldManager:
         logger.debug(f"destory process group for {world_name}")
         self.set_world(world_name)
         del self._worlds[world_name]
-        dist.destroy_process_group()
+        # FIXME: calling destroy_process_group() here causes program hang.
+        #        we need to find out a right timing/way to call this function.
+        #        calling this function is temporarily disabled.
+        # dist.destroy_process_group()
         logger.debug(f"done removing world {world_name}")
 
     def set_world(self, world_name):


### PR DESCRIPTION
## Description

When a broken world (process group) is detected, attempting to destroy the process group causes the program to hang. We temporarily disable this call to prevent this deadlock situation. We will revisit this later.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
