### PR TITLE
misc+doc: patch file for pytorch's nccl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,21 @@ The framework is built on top of PyTorch, a widely-used deep learning framework,
 
 * Install [anaconda](www.anaconda.com/download/) or [miniconda](https://docs.conda.io/en/latest/miniconda.html) in order to create the environment.
 * Clone repo (you could use `git clone https://github.com/cisco-open/pymultiworld.git`).
+* This prerequiste is only for testing a fault tolerance functionality across hosts.
+  * To test the functionality **in a single machine**, this step can be skipped. Do the remaining installation steps from [here](#installation).
+  * Too run the test **across hosts**, a custom-built PyTorch is necessary. Follow instructions in this [doc](docs/pytorch_build.md). Details on why to build a custom PyTorch are found in the doc too.
 
 ## Installation
 
 ### Step 1: Install multiworld package
+
+To use the latest official package,
+
+```bash
+pip install multiworld
+```
+
+To install the package from source,
 
 ```bash
 pip install .
@@ -138,7 +149,7 @@ pydoc multiworld/world_manager.py
 ## Contributors
 
 <a href="https://github.com/cisco-open/pymultiworld/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cisco-open/pymultiworld" />
+  <img src="https://contrib.rocks/image?repo=cisco-open/pymultiworld" alt="contributors" />
 </a>
 
 ## How to Contribute

--- a/docs/pytorch_build.md
+++ b/docs/pytorch_build.md
@@ -1,0 +1,80 @@
+# Patching and Building PyTorch for NCCL
+
+PyTorch provides an environment variable `TORCH_NCCL_ASYNC_ERROR_HANDLING` that offers a means on how to handle errors.
+For that, by setting the variable to "2" (`CleanUpOnly`), applications can handle the error.
+The application-level error handling functionality is key to supporting fault management functionality in Multiworld.
+Currently PyTorch puts a hard restriction on how to handle NCCL error, which breaks the `CleanUpOnly` mode.
+Also, it has a bug on handling NCCL's error code. The ncclRemoteError code defined in NCCL was added into ncclResult_t type
+since nccl v2.13.4. In pytorch's code, the error code is missing. This causes the Unconvertible NCCL type error
+when a remote worker terminates or crashes.
+
+We plan to upstream these changes into the official PyTorch repository.
+To facilitate testing and development of Multiworld, this guideline describes how to patch PyTorch for NCCL.
+The PyTorch version used for this patch is v2.2.1. In order to build PyTorch for versions > v2.2.1,
+a patch file should be created for the target version by examining the patch file provided in this guideline
+since the patch file is created for v2.2.1.
+
+## Prerequisites
+
+The patch is based on Linux. We rely on conda to keep the build environment consistent across Linux distributions.
+The rest of this guideline assumes that Anaconda or Miniconda is installed and initialized and CUDA is available.
+It also assumes that `pymultiworld` repository is is cloned too; PYMULTIWORLD_HOME denotes a path to the cloned repository.
+
+## Build and Installation Steps
+
+### Step 1: Clone torch-build repository
+
+```bash
+git clone --depth 1 --branch v221 https://github.com/myungjin/torch-build.git
+cd torch-build
+```
+
+### Step 2: Set up a conda conda environment
+
+```bash
+conda env create -f pytorch-dev.yaml
+conda activate pytorch-dev
+```
+
+### Step 3: Clone PyTorch repository
+
+```bash
+./torch-clone.sh
+```
+
+### Step 4: Patch PyTorch
+
+```bash
+pushd ~/github/pytorch
+patch -p1 < PYMULTIWORLD_HOME/patch/pytorch-v2.2.1-nccl.patch
+popd
+```
+
+Replace PYMULTIWORLD_HOME with the actual path of pymultiworld's repository path.
+
+### Step 5: Build PyTorch
+
+```bash
+./pytorch-build.sh
+```
+
+### Step 6: Install PyTorch
+
+```bash
+./pytorch-install.sh
+```
+
+### Step 7: Configure other machines
+
+In order to use the custom-built PyTorch in other machines, follow Steps 1 and 2 in those machines.
+And copy the wheel file located `~/github/pytorch/dist` into the machines for example by using `scp`.
+While the `pytorch-dev` conda environment being activated, run the following command:
+
+```bash
+pip install WHEEL_FILE
+```
+
+Replace WHEEL_FILE with the actual file name (e.g., `torch-2.2.1-cp310-cp310-linux_x86_64.whl`).
+
+That's it. Now we are ready to install `multiworld`.
+Go back to the [installation section](../README.md#installation) and follow the remaining steps.

--- a/patch/pytorch-v2.2.1-nccl.patch
+++ b/patch/pytorch-v2.2.1-nccl.patch
@@ -1,0 +1,76 @@
+diff --git a/torch/csrc/cuda/nccl.cpp b/torch/csrc/cuda/nccl.cpp
+index 67b9d54f18b..e165fe36a57 100644
+--- a/torch/csrc/cuda/nccl.cpp
++++ b/torch/csrc/cuda/nccl.cpp
+@@ -47,12 +47,14 @@ ncclResult_t to_nccl_result(torch::cuda::nccl::ncclResult var) {
+       return ncclResult_t::ncclInvalidArgument;
+     case torch::cuda::nccl::ncclResult::InvalidUsage:
+       return ncclResult_t::ncclInvalidUsage;
+-    case torch::cuda::nccl::ncclResult::NumResults:
+-      return ncclResult_t::ncclNumResults;
++    case torch::cuda::nccl::ncclResult::RemoteError:
++      return ncclResult_t::ncclRemoteError;
+ #ifdef NCCL_HAS_COMM_NONBLOCKING
+     case torch::cuda::nccl::ncclResult::InProgress:
+       return ncclResult_t::ncclInProgress;
+ #endif
++    case torch::cuda::nccl::ncclResult::NumResults:
++      return ncclResult_t::ncclNumResults;
+     default:
+       throw std::runtime_error("Unconvertible NCCL type");
+   }
+@@ -72,12 +74,14 @@ torch::cuda::nccl::ncclResult from_nccl_result(ncclResult_t var) {
+       return torch::cuda::nccl::ncclResult::InvalidArgument;
+     case ncclInvalidUsage:
+       return torch::cuda::nccl::ncclResult::InvalidUsage;
+-    case ncclNumResults:
+-      return torch::cuda::nccl::ncclResult::NumResults;
++    case ncclRemoteError:
++      return torch::cuda::nccl::ncclResult::RemoteError;
+ #ifdef NCCL_HAS_COMM_NONBLOCKING
+     case ncclInProgress:
+       return torch::cuda::nccl::ncclResult::InProgress;
+ #endif
++    case ncclNumResults:
++      return torch::cuda::nccl::ncclResult::NumResults;
+     default:
+       throw std::runtime_error("Unconvertible NCCL type");
+   }
+diff --git a/torch/csrc/cuda/nccl.h b/torch/csrc/cuda/nccl.h
+index 14664cc0b9f..6f2015d8040 100644
+--- a/torch/csrc/cuda/nccl.h
++++ b/torch/csrc/cuda/nccl.h
+@@ -44,8 +44,9 @@ enum class ncclResult {
+   InternalError = 3,
+   InvalidArgument = 4,
+   InvalidUsage = 5,
+-  NumResults = 6,
+-  InProgress = 7
++  RemoteError = 6,
++  InProgress = 7,
++  NumResults = 8
+ };
+ 
+ /* Reduction operation selector */
+diff --git a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+index 6652a991d72..8d1994b7bbb 100644
+--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
++++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+@@ -2175,8 +2175,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
+   }
+ 
+   {
+-    torch::cuda::nccl::AutoNcclGroup nccl_group_guard(
+-        comms_, nccl_use_nonblocking());
+     for (const auto i : c10::irange(inputs.size())) {
+       if (!inputs_same_dev || (inputs_same_dev && i == 0)) {
+         gpuGuard.set_index(devices[i].index());
+@@ -2375,8 +2373,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
+     }
+   }
+   {
+-    torch::cuda::nccl::AutoNcclGroup nccl_group_guard(
+-        comms_, nccl_use_nonblocking());
+     for (const auto i : c10::irange(tensors.size())) {
+       gpuGuard.set_index(devices[i].index());
+       at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];


### PR DESCRIPTION
## Description

This patch file updates the ncclResult_t type. ncclRemoteError code is added since nccl v2.13.4. In pytorch's code, the code is not updated. This causes the Unconvertible NCCL type error when a remote worker terminates or crashes.

Also, 'AutoNcclGroup nccl_group_guard' is removed to allow 'TORCH_NCCL_ASYNC_ERROR_HANDLING = 2 (CleanUpOnly)' to work. with nccl_group_guard, a new exception is thrown while another exception is propagating, which causes the termination of the process in c++. To make CleanUpOnly possible, this guard is removed.

The details on this patch are also documented.
## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
