### PR TITLE
fix: fixed stdout not being flushed

### DIFF
--- a/multiworld/world_manager.py
+++ b/multiworld/world_manager.py
@@ -19,6 +19,7 @@ import asyncio
 import concurrent.futures
 import logging
 import os
+import sys
 from asyncio import Queue as ASyncQ
 from datetime import timedelta
 from queue import Queue as SyncQ
@@ -56,6 +57,7 @@ class WorldManager:
         #       terminationof the process. We need to figure out why
         #       sometimes it's not terminated without explicit call of
         #       os._exit(0).
+        sys.stdout.flush()
         os._exit(0)
 
     async def _cleanup_worlds(self):


### PR DESCRIPTION
whenver the os._exit(0) was called, stdout wasn't flushed
resulting in missing logs for the user
before exiting, the flush is forced using flush() method

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
