### PR TITLE
nit: keyerror exception handling

### DIFF
--- a/multiworld/world_manager.py
+++ b/multiworld/world_manager.py
@@ -152,10 +152,13 @@ class WorldManager:
         self._communicator.remove_world(world_name)
 
         logger.debug(f"remove {world_name} from world stores")
-        del self._worlds_stores[world_name]
+        try:
+            del self._worlds_stores[world_name]
+        except KeyError:
+            pass
 
         logger.debug(f"destory process group for {world_name}")
-        # FIXME: the following two lindes of code here causes program hang.
+        # FIXME: the following two lines of code here causes program hang.
         #        we need to find out a right timing/way to call them.
         #        calling them is temporarily disabled.
         # dist.destroy_process_group(name=world_name)


### PR DESCRIPTION
## Description

There is a chance that remove_world in world_manager is called twice. The funcall call removes a key from worlds_stores. So, the second call leads to KeyError.
We currently can't ensure call the function only once because the current remove_world is not clean due to a deadlock issue. So, we mask the key error.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
