### PR TITLE
fix: incorrect worldstatus list allocation

### DIFF
--- a/multiworld/watchdog.py
+++ b/multiworld/watchdog.py
@@ -116,7 +116,11 @@ class WatchDog:
 
             if not empty:
                 logger.debug(f"name: {world}, rank: {rank}, world size: {size}")
-                self._myworlds[world] = (store, rank, [WorldStatus()] * size)
+                self._myworlds[world] = (
+                    store,
+                    rank,
+                    [WorldStatus() for i in range(size)],
+                )
 
             # update tick for all the worlds that I belongs to
             broken_worlds = set()


### PR DESCRIPTION
## Description

WorldStatus list is incorrectly initialized. All the entries in the list points to the same address. This makes a buggy update for world's status. This issue is fixed here.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
