### PR TITLE
refactor: nccl's async error handling in pytorch

### DIFF
--- a/examples/all_gather/m8d.py
+++ b/examples/all_gather/m8d.py
@@ -159,10 +159,6 @@ if __name__ == "__main__":
     # for example: --worldinfo 1,0` means world with the index 1 will have a rank 0
     parser.add_argument("--worldinfo", type=str, action="append")
 
-    # https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L114-L126
-    # "2" is CleanUpOnly
-    os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "2"
-
     args = parser.parse_args()
 
     loop = asyncio.get_event_loop()

--- a/examples/all_reduce/m8d.py
+++ b/examples/all_reduce/m8d.py
@@ -150,10 +150,6 @@ if __name__ == "__main__":
     parser.add_argument("--addr", default="127.0.0.1")
     parser.add_argument("--worldinfo", type=str, action="append")
 
-    # https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L114-L126
-    # "2" is CleanUpOnly
-    os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "2"
-
     args = parser.parse_args()
 
     loop = asyncio.get_event_loop()

--- a/examples/broadcast/m8d.py
+++ b/examples/broadcast/m8d.py
@@ -154,10 +154,6 @@ if __name__ == "__main__":
     # for example: --worldinfo 1,0` means world with the index 1 will have a rank 0
     parser.add_argument("--worldinfo", type=str, action="append")
 
-    # https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L114-L126
-    # "2" is CleanUpOnly
-    os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "2"
-
     args = parser.parse_args()
 
     loop = asyncio.get_event_loop()

--- a/examples/reduce/m8d.py
+++ b/examples/reduce/m8d.py
@@ -95,7 +95,12 @@ async def reduce(world_name, world_size, rank, backend):
 
         if dst == rank:
             print(
-                "Rank ", rank, " within world ", world_name, " has reduced tensor", tensor
+                "Rank ",
+                rank,
+                " within world ",
+                world_name,
+                " has reduced tensor",
+                tensor,
             )
 
         print(f"done with step: {step}")
@@ -153,10 +158,6 @@ if __name__ == "__main__":
     parser.add_argument("--backend", default="gloo")
     parser.add_argument("--addr", default="127.0.0.1")
     parser.add_argument("--worldinfo", type=str, action="append")
-
-    # https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L114-L126
-    # "2" is CleanUpOnly
-    os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "2"
 
     args = parser.parse_args()
 

--- a/examples/resnet/m8d.py
+++ b/examples/resnet/m8d.py
@@ -384,10 +384,6 @@ if __name__ == "__main__":
         "--multihost", action=argparse.BooleanOptionalAction, default=False
     )
 
-    # https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L114-L126
-    # "2" is CleanUpOnly
-    os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "2"
-
     args = parser.parse_args()
     atexit.register(cleanup)
 

--- a/examples/send_recv/m8d.py
+++ b/examples/send_recv/m8d.py
@@ -191,10 +191,6 @@ if __name__ == "__main__":
     parser.add_argument("--addr", default="127.0.0.1")
     parser.add_argument("--worldinfo", type=str, action="append")
 
-    # https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L114-L126
-    # "2" is CleanUpOnly
-    os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "2"
-
     args = parser.parse_args()
 
     loop = asyncio.get_event_loop()

--- a/multiworld/world_manager.py
+++ b/multiworld/world_manager.py
@@ -38,6 +38,12 @@ class WorldManager:
 
     def __init__(self, enable_monitor=True):
         """Initialize a world manager."""
+        # https://github.com/pytorch/pytorch/blob/v2.4.0/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L118-L130
+        # "2" is CleanUpOnly
+        # We use CleanupOnly in order to allow error handling at user process
+        # level without tearing down the process.
+        os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "2"
+
         self._worlds_stores: dict[str, dist.TCPStore] = dict()
         self._communicator = WorldCommunicator(self)
         self._current_world = ""


### PR DESCRIPTION
## Description

The default option to handle errors of nccl operations in PyTorch is to tear down the process. In a multiworld setting, we need to handle error gracefully by tearing down the world that encounter the errors. In order to do so, we set the environment variable, TORCH_NCCL_ASYNC_ERROR_HANDLING, with "2" (i.e., CleanupOnly) in the World Manager''s init function. In this way, users don't need to set the environment variable in their applications. Thus, in the examples, we removed the code snippet that sets the environment variable.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
