### PR TITLE
fix: error handle in initial configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ The framework is built on top of PyTorch, a widely-used deep learning framework,
 
 ## Installation
 
-### Step 1: Install multiworld package
-
 To use the latest official package,
 
 ```bash
@@ -54,12 +52,6 @@ To install the package from source,
 
 ```bash
 pip install .
-```
-
-### Step 2: Run post installation script
-
-```bash
-m8d-post-setup
 ```
 
 ## Running Examples

--- a/multiworld/post_setup.py
+++ b/multiworld/post_setup.py
@@ -22,13 +22,21 @@ import sys
 
 
 def configure_once():
+    """Configure multiworld once when it is used for the first time."""
     package_name = __name__.split(".")[0]
     path_to_sitepackages = site.getsitepackages()[0]
 
     init_file_path = os.path.join(path_to_sitepackages, package_name, "init.txt")
 
-    with open(init_file_path, "r") as file:
-        patch_applied = file.read()
+    try:
+        with open(init_file_path, "r") as file:
+            patch_applied = file.read()
+    except FileNotFoundError:
+        message = "WARNING: initialization check file not found; "
+        message += f"{package_name} is not installed correctly; "
+        message += "please reinstall."
+        print(message)
+        return
 
     if patch_applied == "true":
         return


### PR DESCRIPTION
## Description

When post installation script is triggered during installation, the initialization check file (init.txt) is not present, which raises an exception. This leads to the failed installation. The issue is fixed by catching the error and suppressing it (which is okay because it is only happening during the installation).

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
