### PR TITLE
feat: eager pytorch nccl communicator initialization

### DIFF
--- a/examples/all_gather/m8d.py
+++ b/examples/all_gather/m8d.py
@@ -40,8 +40,16 @@ async def init_world(world_name, rank, size, backend="gloo", addr="127.0.0.1", p
         addr (str): Address to use for communication.
         port (int): Port to use for communication.
     """
+    dev_str = f"cuda:{rank}" if backend == "nccl" else "cpu"
+
     await world_manager.initialize_world(
-        world_name, rank, size, backend=backend, addr=addr, port=port
+        world_name,
+        rank,
+        size,
+        backend=backend,
+        addr=addr,
+        port=port,
+        device=torch.device(dev_str),
     )
 
 

--- a/examples/all_reduce/m8d.py
+++ b/examples/all_reduce/m8d.py
@@ -41,8 +41,16 @@ async def init_world(world_name, rank, size, backend="gloo", addr="127.0.0.1", p
         addr (str): Address to use for communication.
         port (int): Port to use for communication.
     """
+    dev_str = f"cuda:{rank}" if backend == "nccl" else "cpu"
+
     await world_manager.initialize_world(
-        world_name, rank, size, backend=backend, addr=addr, port=port
+        world_name,
+        rank,
+        size,
+        backend=backend,
+        addr=addr,
+        port=port,
+        device=torch.device(dev_str),
     )
 
 

--- a/examples/broadcast/m8d.py
+++ b/examples/broadcast/m8d.py
@@ -40,8 +40,16 @@ async def init_world(world_name, rank, size, backend="gloo", addr="127.0.0.1", p
         addr (str): Address to use for communication.
         port (int): Port to use for communication.
     """
+    dev_str = f"cuda:{rank}" if backend == "nccl" else "cpu"
+
     await world_manager.initialize_world(
-        world_name, rank, size, backend=backend, addr=addr, port=port
+        world_name,
+        rank,
+        size,
+        backend=backend,
+        addr=addr,
+        port=port,
+        device=torch.device(dev_str),
     )
 
 

--- a/examples/gather/m8d.py
+++ b/examples/gather/m8d.py
@@ -40,8 +40,16 @@ async def init_world(world_name, rank, size, backend="gloo", addr="127.0.0.1", p
         addr (str): Address to use for communication.
         port (int): Port to use for communication.
     """
+    dev_str = f"cuda:{rank}" if backend == "nccl" else "cpu"
+
     await world_manager.initialize_world(
-        world_name, rank, size, backend=backend, addr=addr, port=port
+        world_name,
+        rank,
+        size,
+        backend=backend,
+        addr=addr,
+        port=port,
+        device=torch.device(dev_str),
     )
 
 

--- a/examples/reduce/m8d.py
+++ b/examples/reduce/m8d.py
@@ -41,8 +41,16 @@ async def init_world(world_name, rank, size, backend="gloo", addr="127.0.0.1", p
         addr (str): Address to use for communication.
         port (int): Port to use for communication.
     """
+    dev_str = f"cuda:{rank}" if backend == "nccl" else "cpu"
+
     await world_manager.initialize_world(
-        world_name, rank, size, backend=backend, addr=addr, port=port
+        world_name,
+        rank,
+        size,
+        backend=backend,
+        addr=addr,
+        port=port,
+        device=torch.device(dev_str),
     )
 
 

--- a/examples/resnet/m8d.py
+++ b/examples/resnet/m8d.py
@@ -192,8 +192,17 @@ async def init_world(
         # TODO: make WorldManager as singleton
         world_manager = WorldManager()
 
+    world_idx = int(world_name[5:])
+    dev_str = f"cuda:{world_idx}" if backend == "nccl" else "cpu"
+
     await world_manager.initialize_world(
-        world_name, rank, size, backend=backend, addr=addr, port=port
+        world_name,
+        rank,
+        size,
+        backend=backend,
+        addr=addr,
+        port=port,
+        device=torch.device(dev_str),
     )
 
     await fn(world_name, rank, size, backend, world_manager.communicator)

--- a/examples/scatter/m8d.py
+++ b/examples/scatter/m8d.py
@@ -39,8 +39,16 @@ async def init_world(world_name, rank, size, backend="gloo", addr="127.0.0.1", p
         addr (str): Address to use for communication.
         port (int): Port to use for communication.
     """
+    dev_str = f"cuda:{rank}" if backend == "nccl" else "cpu"
+
     await world_manager.initialize_world(
-        world_name, rank, size, backend=backend, addr=addr, port=port
+        world_name,
+        rank,
+        size,
+        backend=backend,
+        addr=addr,
+        port=port,
+        device=torch.device(dev_str),
     )
 
 

--- a/examples/send_recv/m8d.py
+++ b/examples/send_recv/m8d.py
@@ -40,8 +40,16 @@ async def init_world(world_name, rank, size, backend="gloo", addr="127.0.0.1", p
         addr (str): Address to use for communication.
         port (int): Port to use for communication.
     """
+    dev_str = f"cuda:{rank}" if backend == "nccl" else "cpu"
+
     await world_manager.initialize_world(
-        world_name, rank, size, backend=backend, addr=addr, port=port
+        world_name,
+        rank,
+        size,
+        backend=backend,
+        addr=addr,
+        port=port,
+        device=torch.device(dev_str),
     )
 
 


### PR DESCRIPTION
## Description

Pytorch initializes nccl communicator in a lazy fashion. Initializing nccl communicator requires a collective operation such as all reduce. To maker sure that communicator is quickly ready for heavy tensor tx/rx, a dummy all reduce operation is executed every time a new world is initialized.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
