### PR TITLE
fix: watchdog deadlock check on recovery

### DIFF
--- a/multiworld/watchdog.py
+++ b/multiworld/watchdog.py
@@ -154,6 +154,9 @@ class WatchDog:
             # if there is a broken world, check if deadlock occurs.
             if len(cleanup_entries) > 0:
                 self._deadlock_check_trigger.set()
+            else:
+            # if no broken world, or the worlds are recovered, block deadlock check
+                self._deadlock_check_trigger.clear()
 
             tick += 1
             time.sleep(UPDATE_PERIOD)


### PR DESCRIPTION
## Description

When a broken world is identified, watchdog starts to send SIGUSR1 messages. But whenever these worlds are recovered, we need to bock the thread execution for the previous worlds. So whenever a new set of broken worlds is received, the event is unblocked and it can continue to send messages. The cleanup of the broken worlds is already handled by watchdog.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
