### PR TITLE
misc: clean watchdog logs

### DIFF
--- a/multiworld/watchdog.py
+++ b/multiworld/watchdog.py
@@ -73,10 +73,7 @@ class WatchDog:
     def _deadlock_check(self):
         global _deadlock_check_var
 
-        logger.debug("let's check if main thread is blocked or not")
-
         os.kill(os.getpid(), signal.SIGUSR1)
-        logger.debug("sent SIGUSR1")
 
         time.sleep(DEADLOCK_CHECK_WAIT_TIME)
         if _deadlock_check_var == 0:
@@ -197,7 +194,6 @@ def usr1_handler(signum, frame):
     to inform watchdog that the main thread is working fine.
     """
     global _deadlock_check_var
-    logger.debug("received SIGUSR1")
     _deadlock_check_var = 1
 
 


### PR DESCRIPTION
## Description

Removed logs that are misleading from watchdog. Whenever watchdog identifies a broken world, it starts to send SIGUSR1 messages to check the deadlock. These messages are sent continuously for 50 seconds. That is correct, but the log messages are misleading. If there is an actual deadlock, there are logs that will be displayed for that reason.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
